### PR TITLE
fix: fixed timestamp based container vulnerability scans to all githu…

### DIFF
--- a/.github/workflows/dev-pr-workflow.yaml
+++ b/.github/workflows/dev-pr-workflow.yaml
@@ -126,11 +126,12 @@ jobs:
 
     - name: Moving scan results to approapriate folders
       run: |
-        mv -f helm_results.sarif reports/kubernetes-nsa-cisa-yaml-scan-analysis/helm_results.sarif
-        mv -f consul.sarif reports/container-security-analysis/consul.sarif
-        mv -f consul-control-plane.sarif reports/container-security-analysis/consul-control-plane.sarif
-        mv -f consul-data-plane.sarif reports/container-security-analysis/consul-data-plane.sarif
-        mv -f consul-envoy.sarif reports/container-security-analysis/consul-envoy.sarif
+        TIMESTAMP=$(date -u +%Y%m%d%H%M%S)s
+        mv -f helm_results.sarif reports/kubernetes-nsa-cisa-yaml-scan-analysis/helm_results_${TIMESTAMP}.sarif
+        mv -f consul.sarif reports/container-security-analysis/consul_${TIMESTAMP}.sarif
+        mv -f consul-control-plane.sarif reports/container-security-analysis/consul-control-plane_${TIMESTAMP}.sarif
+        mv -f consul-data-plane.sarif reports/container-security-analysis/consul-data-plane_${TIMESTAMP}.sarif
+        mv -f consul-envoy.sarif reports/container-security-analysis/consul-envoy_${TIMESTAMP}.sarif
 
     - name: Push changes to our repository
       run: |

--- a/.github/workflows/sync-upstream-consul.yaml
+++ b/.github/workflows/sync-upstream-consul.yaml
@@ -142,12 +142,14 @@ jobs:
         category: "Container scan for Consul Envoy"   
     
     - name: Moving scan results to approapriate folders
+      if: env.NEW_BRANCH_CREATED == 'true'
       run: |
-        mv -f helm_results.sarif reports/kubernetes-nsa-cisa-yaml-scan-analysis/helm_results.sarif
-        mv -f consul.sarif reports/container-security-analysis/consul.sarif
-        mv -f consul-control-plane.sarif reports/container-security-analysis/consul-control-plane.sarif
-        mv -f consul-data-plane.sarif reports/container-security-analysis/consul-data-plane.sarif
-        mv -f consul-envoy.sarif reports/container-security-analysis/consul-envoy.sarif 
+        TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+        mv -f helm_results.sarif reports/kubernetes-nsa-cisa-yaml-scan-analysis/helm_results_${TIMESTAMP}.sarif
+        mv -f consul.sarif reports/container-security-analysis/consul_${TIMESTAMP}.sarif
+        mv -f consul-control-plane.sarif reports/container-security-analysis/consul-control-plane_${TIMESTAMP}.sarif
+        mv -f consul-data-plane.sarif reports/container-security-analysis/consul-data-plane_${TIMESTAMP}.sarif
+        mv -f consul-envoy.sarif reports/container-security-analysis/consul-envoy_${TIMESTAMP}.sarif 
 
     - name: Helm Chart Scan
       if: env.NEW_BRANCH_CREATED == 'true'

--- a/reports/container-security-analysis/consul-control-plane.sarif
+++ b/reports/container-security-analysis/consul-control-plane.sarif
@@ -199,6 +199,87 @@
               }
             },
             {
+              "id": "CVE-2022-27664",
+              "name": "LanguageSpecificPackageVulnerability",
+              "shortDescription": {
+                "text": "handle server errors after sending GOAWAY"
+              },
+              "fullDescription": {
+                "text": "In net/http in Go before 1.18.6 and 1.19.x before 1.19.1, attackers can cause a denial of service because an HTTP/2 connection can hang during closing if shutdown were preempted by a fatal error."
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://avd.aquasec.com/nvd/cve-2022-27664",
+              "help": {
+                "text": "Vulnerability CVE-2022-27664\nSeverity: HIGH\nPackage: golang.org/x/net\nFixed Version: 0.0.0-20220906165146-f3363e06e74c\nLink: [CVE-2022-27664](https://avd.aquasec.com/nvd/cve-2022-27664)\nIn net/http in Go before 1.18.6 and 1.19.x before 1.19.1, attackers can cause a denial of service because an HTTP/2 connection can hang during closing if shutdown were preempted by a fatal error.",
+                "markdown": "**Vulnerability CVE-2022-27664**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|golang.org/x/net|0.0.0-20220906165146-f3363e06e74c|[CVE-2022-27664](https://avd.aquasec.com/nvd/cve-2022-27664)|\n\nIn net/http in Go before 1.18.6 and 1.19.x before 1.19.1, attackers can cause a denial of service because an HTTP/2 connection can hang during closing if shutdown were preempted by a fatal error."
+              },
+              "properties": {
+                "precision": "very-high",
+                "security-severity": "7.5",
+                "tags": [
+                  "vulnerability",
+                  "security",
+                  "HIGH"
+                ]
+              }
+            },
+            {
+              "id": "CVE-2022-41723",
+              "name": "LanguageSpecificPackageVulnerability",
+              "shortDescription": {
+                "text": "avoid quadratic complexity in HPACK decoding"
+              },
+              "fullDescription": {
+                "text": "A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests."
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://avd.aquasec.com/nvd/cve-2022-41723",
+              "help": {
+                "text": "Vulnerability CVE-2022-41723\nSeverity: HIGH\nPackage: golang.org/x/net\nFixed Version: 0.7.0\nLink: [CVE-2022-41723](https://avd.aquasec.com/nvd/cve-2022-41723)\nA maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.",
+                "markdown": "**Vulnerability CVE-2022-41723**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|golang.org/x/net|0.7.0|[CVE-2022-41723](https://avd.aquasec.com/nvd/cve-2022-41723)|\n\nA maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests."
+              },
+              "properties": {
+                "precision": "very-high",
+                "security-severity": "7.5",
+                "tags": [
+                  "vulnerability",
+                  "security",
+                  "HIGH"
+                ]
+              }
+            },
+            {
+              "id": "CVE-2022-32149",
+              "name": "LanguageSpecificPackageVulnerability",
+              "shortDescription": {
+                "text": "ParseAcceptLanguage takes a long time to parse complex tags"
+              },
+              "fullDescription": {
+                "text": "An attacker may cause a denial of service by crafting an Accept-Language header which ParseAcceptLanguage will take significant time to parse."
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://avd.aquasec.com/nvd/cve-2022-32149",
+              "help": {
+                "text": "Vulnerability CVE-2022-32149\nSeverity: HIGH\nPackage: golang.org/x/text\nFixed Version: 0.3.8\nLink: [CVE-2022-32149](https://avd.aquasec.com/nvd/cve-2022-32149)\nAn attacker may cause a denial of service by crafting an Accept-Language header which ParseAcceptLanguage will take significant time to parse.",
+                "markdown": "**Vulnerability CVE-2022-32149**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|golang.org/x/text|0.3.8|[CVE-2022-32149](https://avd.aquasec.com/nvd/cve-2022-32149)|\n\nAn attacker may cause a denial of service by crafting an Accept-Language header which ParseAcceptLanguage will take significant time to parse."
+              },
+              "properties": {
+                "precision": "very-high",
+                "security-severity": "7.5",
+                "tags": [
+                  "vulnerability",
+                  "security",
+                  "HIGH"
+                ]
+              }
+            },
+            {
               "id": "CVE-2020-8911",
               "name": "LanguageSpecificPackageVulnerability",
               "shortDescription": {
@@ -442,60 +523,6 @@
               }
             },
             {
-              "id": "CVE-2022-27664",
-              "name": "LanguageSpecificPackageVulnerability",
-              "shortDescription": {
-                "text": "handle server errors after sending GOAWAY"
-              },
-              "fullDescription": {
-                "text": "In net/http in Go before 1.18.6 and 1.19.x before 1.19.1, attackers can cause a denial of service because an HTTP/2 connection can hang during closing if shutdown were preempted by a fatal error."
-              },
-              "defaultConfiguration": {
-                "level": "error"
-              },
-              "helpUri": "https://avd.aquasec.com/nvd/cve-2022-27664",
-              "help": {
-                "text": "Vulnerability CVE-2022-27664\nSeverity: HIGH\nPackage: golang.org/x/net\nFixed Version: 0.0.0-20220906165146-f3363e06e74c\nLink: [CVE-2022-27664](https://avd.aquasec.com/nvd/cve-2022-27664)\nIn net/http in Go before 1.18.6 and 1.19.x before 1.19.1, attackers can cause a denial of service because an HTTP/2 connection can hang during closing if shutdown were preempted by a fatal error.",
-                "markdown": "**Vulnerability CVE-2022-27664**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|golang.org/x/net|0.0.0-20220906165146-f3363e06e74c|[CVE-2022-27664](https://avd.aquasec.com/nvd/cve-2022-27664)|\n\nIn net/http in Go before 1.18.6 and 1.19.x before 1.19.1, attackers can cause a denial of service because an HTTP/2 connection can hang during closing if shutdown were preempted by a fatal error."
-              },
-              "properties": {
-                "precision": "very-high",
-                "security-severity": "7.5",
-                "tags": [
-                  "vulnerability",
-                  "security",
-                  "HIGH"
-                ]
-              }
-            },
-            {
-              "id": "CVE-2022-41723",
-              "name": "LanguageSpecificPackageVulnerability",
-              "shortDescription": {
-                "text": "avoid quadratic complexity in HPACK decoding"
-              },
-              "fullDescription": {
-                "text": "A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests."
-              },
-              "defaultConfiguration": {
-                "level": "error"
-              },
-              "helpUri": "https://avd.aquasec.com/nvd/cve-2022-41723",
-              "help": {
-                "text": "Vulnerability CVE-2022-41723\nSeverity: HIGH\nPackage: golang.org/x/net\nFixed Version: 0.7.0\nLink: [CVE-2022-41723](https://avd.aquasec.com/nvd/cve-2022-41723)\nA maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.",
-                "markdown": "**Vulnerability CVE-2022-41723**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|golang.org/x/net|0.7.0|[CVE-2022-41723](https://avd.aquasec.com/nvd/cve-2022-41723)|\n\nA maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests."
-              },
-              "properties": {
-                "precision": "very-high",
-                "security-severity": "7.5",
-                "tags": [
-                  "vulnerability",
-                  "security",
-                  "HIGH"
-                ]
-              }
-            },
-            {
               "id": "CVE-2021-31525",
               "name": "LanguageSpecificPackageVulnerability",
               "shortDescription": {
@@ -565,33 +592,6 @@
               "help": {
                 "text": "Vulnerability CVE-2021-38561\nSeverity: HIGH\nPackage: golang.org/x/text\nFixed Version: 0.3.7\nLink: [CVE-2021-38561](https://avd.aquasec.com/nvd/cve-2021-38561)\ngolang.org/x/text/language in golang.org/x/text before 0.3.7 can panic with an out-of-bounds read during BCP 47 language tag parsing. Index calculation is mishandled. If parsing untrusted user input, this can be used as a vector for a denial-of-service attack.",
                 "markdown": "**Vulnerability CVE-2021-38561**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|golang.org/x/text|0.3.7|[CVE-2021-38561](https://avd.aquasec.com/nvd/cve-2021-38561)|\n\ngolang.org/x/text/language in golang.org/x/text before 0.3.7 can panic with an out-of-bounds read during BCP 47 language tag parsing. Index calculation is mishandled. If parsing untrusted user input, this can be used as a vector for a denial-of-service attack."
-              },
-              "properties": {
-                "precision": "very-high",
-                "security-severity": "7.5",
-                "tags": [
-                  "vulnerability",
-                  "security",
-                  "HIGH"
-                ]
-              }
-            },
-            {
-              "id": "CVE-2022-32149",
-              "name": "LanguageSpecificPackageVulnerability",
-              "shortDescription": {
-                "text": "ParseAcceptLanguage takes a long time to parse complex tags"
-              },
-              "fullDescription": {
-                "text": "An attacker may cause a denial of service by crafting an Accept-Language header which ParseAcceptLanguage will take significant time to parse."
-              },
-              "defaultConfiguration": {
-                "level": "error"
-              },
-              "helpUri": "https://avd.aquasec.com/nvd/cve-2022-32149",
-              "help": {
-                "text": "Vulnerability CVE-2022-32149\nSeverity: HIGH\nPackage: golang.org/x/text\nFixed Version: 0.3.8\nLink: [CVE-2022-32149](https://avd.aquasec.com/nvd/cve-2022-32149)\nAn attacker may cause a denial of service by crafting an Accept-Language header which ParseAcceptLanguage will take significant time to parse.",
-                "markdown": "**Vulnerability CVE-2022-32149**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|golang.org/x/text|0.3.8|[CVE-2022-32149](https://avd.aquasec.com/nvd/cve-2022-32149)|\n\nAn attacker may cause a denial of service by crafting an Accept-Language header which ParseAcceptLanguage will take significant time to parse."
               },
               "properties": {
                 "precision": "very-high",
@@ -1203,8 +1203,89 @@
           ]
         },
         {
-          "ruleId": "CVE-2020-8911",
+          "ruleId": "CVE-2022-27664",
           "ruleIndex": 7,
+          "level": "error",
+          "message": {
+            "text": "Package: golang.org/x/net\nInstalled Version: v0.0.0-20211216030914-fe4d6282115f\nVulnerability CVE-2022-27664\nSeverity: HIGH\nFixed Version: 0.0.0-20220906165146-f3363e06e74c\nLink: [CVE-2022-27664](https://avd.aquasec.com/nvd/cve-2022-27664)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "bin/consul-cni",
+                  "uriBaseId": "ROOTPATH"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 1
+                }
+              },
+              "message": {
+                "text": "bin/consul-cni: golang.org/x/net@v0.0.0-20211216030914-fe4d6282115f"
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "CVE-2022-41723",
+          "ruleIndex": 8,
+          "level": "error",
+          "message": {
+            "text": "Package: golang.org/x/net\nInstalled Version: v0.0.0-20211216030914-fe4d6282115f\nVulnerability CVE-2022-41723\nSeverity: HIGH\nFixed Version: 0.7.0\nLink: [CVE-2022-41723](https://avd.aquasec.com/nvd/cve-2022-41723)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "bin/consul-cni",
+                  "uriBaseId": "ROOTPATH"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 1
+                }
+              },
+              "message": {
+                "text": "bin/consul-cni: golang.org/x/net@v0.0.0-20211216030914-fe4d6282115f"
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "CVE-2022-32149",
+          "ruleIndex": 9,
+          "level": "error",
+          "message": {
+            "text": "Package: golang.org/x/text\nInstalled Version: v0.3.7\nVulnerability CVE-2022-32149\nSeverity: HIGH\nFixed Version: 0.3.8\nLink: [CVE-2022-32149](https://avd.aquasec.com/nvd/cve-2022-32149)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "bin/consul-cni",
+                  "uriBaseId": "ROOTPATH"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 1
+                }
+              },
+              "message": {
+                "text": "bin/consul-cni: golang.org/x/text@v0.3.7"
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "CVE-2020-8911",
+          "ruleIndex": 10,
           "level": "warning",
           "message": {
             "text": "Package: github.com/aws/aws-sdk-go\nInstalled Version: v1.25.41\nVulnerability CVE-2020-8911\nSeverity: MEDIUM\nFixed Version: 1.34.0\nLink: [CVE-2020-8911](https://avd.aquasec.com/nvd/cve-2020-8911)"
@@ -1231,7 +1312,7 @@
         },
         {
           "ruleId": "CVE-2022-2582",
-          "ruleIndex": 8,
+          "ruleIndex": 11,
           "level": "warning",
           "message": {
             "text": "Package: github.com/aws/aws-sdk-go\nInstalled Version: v1.25.41\nVulnerability CVE-2022-2582\nSeverity: MEDIUM\nFixed Version: 1.34.0\nLink: [CVE-2022-2582](https://avd.aquasec.com/nvd/cve-2022-2582)"
@@ -1258,7 +1339,7 @@
         },
         {
           "ruleId": "GHSA-76wf-9vgp-pj7w",
-          "ruleIndex": 9,
+          "ruleIndex": 12,
           "level": "warning",
           "message": {
             "text": "Package: github.com/aws/aws-sdk-go\nInstalled Version: v1.25.41\nVulnerability GHSA-76wf-9vgp-pj7w\nSeverity: MEDIUM\nFixed Version: 1.34.0\nLink: [GHSA-76wf-9vgp-pj7w](https://github.com/advisories/GHSA-76wf-9vgp-pj7w)"
@@ -1285,7 +1366,7 @@
         },
         {
           "ruleId": "CVE-2020-8912",
-          "ruleIndex": 10,
+          "ruleIndex": 13,
           "level": "note",
           "message": {
             "text": "Package: github.com/aws/aws-sdk-go\nInstalled Version: v1.25.41\nVulnerability CVE-2020-8912\nSeverity: LOW\nFixed Version: 1.34.0\nLink: [CVE-2020-8912](https://avd.aquasec.com/nvd/cve-2020-8912)"
@@ -1312,7 +1393,7 @@
         },
         {
           "ruleId": "CVE-2019-19794",
-          "ruleIndex": 11,
+          "ruleIndex": 14,
           "level": "warning",
           "message": {
             "text": "Package: github.com/miekg/dns\nInstalled Version: v1.0.14\nVulnerability CVE-2019-19794\nSeverity: MEDIUM\nFixed Version: 1.1.25\nLink: [CVE-2019-19794](https://avd.aquasec.com/nvd/cve-2019-19794)"
@@ -1339,7 +1420,7 @@
         },
         {
           "ruleId": "CVE-2020-29652",
-          "ruleIndex": 12,
+          "ruleIndex": 15,
           "level": "error",
           "message": {
             "text": "Package: golang.org/x/crypto\nInstalled Version: v0.0.0-20201002170205-7f63de1d35b0\nVulnerability CVE-2020-29652\nSeverity: HIGH\nFixed Version: 0.0.0-20201216223049-8b5274cf687f\nLink: [CVE-2020-29652](https://avd.aquasec.com/nvd/cve-2020-29652)"
@@ -1366,7 +1447,7 @@
         },
         {
           "ruleId": "CVE-2021-43565",
-          "ruleIndex": 13,
+          "ruleIndex": 16,
           "level": "error",
           "message": {
             "text": "Package: golang.org/x/crypto\nInstalled Version: v0.0.0-20201002170205-7f63de1d35b0\nVulnerability CVE-2021-43565\nSeverity: HIGH\nFixed Version: 0.0.0-20211202192323-5770296d904e\nLink: [CVE-2021-43565](https://avd.aquasec.com/nvd/cve-2021-43565)"
@@ -1393,7 +1474,7 @@
         },
         {
           "ruleId": "CVE-2022-27191",
-          "ruleIndex": 14,
+          "ruleIndex": 17,
           "level": "error",
           "message": {
             "text": "Package: golang.org/x/crypto\nInstalled Version: v0.0.0-20201002170205-7f63de1d35b0\nVulnerability CVE-2022-27191\nSeverity: HIGH\nFixed Version: 0.0.0-20220314234659-1baeb1ce4c0b\nLink: [CVE-2022-27191](https://avd.aquasec.com/nvd/cve-2022-27191)"
@@ -1420,7 +1501,7 @@
         },
         {
           "ruleId": "CVE-2021-33194",
-          "ruleIndex": 15,
+          "ruleIndex": 18,
           "level": "error",
           "message": {
             "text": "Package: golang.org/x/net\nInstalled Version: v0.0.0-20191004110552-13f9640d40b9\nVulnerability CVE-2021-33194\nSeverity: HIGH\nFixed Version: 0.0.0-20210520170846-37e1c6afe023\nLink: [CVE-2021-33194](https://avd.aquasec.com/nvd/cve-2021-33194)"
@@ -1447,7 +1528,7 @@
         },
         {
           "ruleId": "CVE-2022-27664",
-          "ruleIndex": 16,
+          "ruleIndex": 7,
           "level": "error",
           "message": {
             "text": "Package: golang.org/x/net\nInstalled Version: v0.0.0-20191004110552-13f9640d40b9\nVulnerability CVE-2022-27664\nSeverity: HIGH\nFixed Version: 0.0.0-20220906165146-f3363e06e74c\nLink: [CVE-2022-27664](https://avd.aquasec.com/nvd/cve-2022-27664)"
@@ -1474,7 +1555,7 @@
         },
         {
           "ruleId": "CVE-2022-41723",
-          "ruleIndex": 17,
+          "ruleIndex": 8,
           "level": "error",
           "message": {
             "text": "Package: golang.org/x/net\nInstalled Version: v0.0.0-20191004110552-13f9640d40b9\nVulnerability CVE-2022-41723\nSeverity: HIGH\nFixed Version: 0.7.0\nLink: [CVE-2022-41723](https://avd.aquasec.com/nvd/cve-2022-41723)"
@@ -1501,7 +1582,7 @@
         },
         {
           "ruleId": "CVE-2021-31525",
-          "ruleIndex": 18,
+          "ruleIndex": 19,
           "level": "warning",
           "message": {
             "text": "Package: golang.org/x/net\nInstalled Version: v0.0.0-20191004110552-13f9640d40b9\nVulnerability CVE-2021-31525\nSeverity: MEDIUM\nFixed Version: 0.0.0-20210428140749-89ef3d95e781\nLink: [CVE-2021-31525](https://avd.aquasec.com/nvd/cve-2021-31525)"
@@ -1528,7 +1609,7 @@
         },
         {
           "ruleId": "CVE-2022-29526",
-          "ruleIndex": 19,
+          "ruleIndex": 20,
           "level": "warning",
           "message": {
             "text": "Package: golang.org/x/sys\nInstalled Version: v0.0.0-20191022100944-742c48ecaeb7\nVulnerability CVE-2022-29526\nSeverity: MEDIUM\nFixed Version: 0.0.0-20220412211240-33da011f77ad\nLink: [CVE-2022-29526](https://avd.aquasec.com/nvd/cve-2022-29526)"
@@ -1555,7 +1636,7 @@
         },
         {
           "ruleId": "CVE-2021-38561",
-          "ruleIndex": 20,
+          "ruleIndex": 21,
           "level": "error",
           "message": {
             "text": "Package: golang.org/x/text\nInstalled Version: v0.3.2\nVulnerability CVE-2021-38561\nSeverity: HIGH\nFixed Version: 0.3.7\nLink: [CVE-2021-38561](https://avd.aquasec.com/nvd/cve-2021-38561)"
@@ -1582,7 +1663,7 @@
         },
         {
           "ruleId": "CVE-2022-32149",
-          "ruleIndex": 21,
+          "ruleIndex": 9,
           "level": "error",
           "message": {
             "text": "Package: golang.org/x/text\nInstalled Version: v0.3.2\nVulnerability CVE-2022-32149\nSeverity: HIGH\nFixed Version: 0.3.8\nLink: [CVE-2022-32149](https://avd.aquasec.com/nvd/cve-2022-32149)"
@@ -1609,7 +1690,7 @@
         },
         {
           "ruleId": "CVE-2020-8911",
-          "ruleIndex": 7,
+          "ruleIndex": 10,
           "level": "warning",
           "message": {
             "text": "Package: github.com/aws/aws-sdk-go\nInstalled Version: v1.25.41\nVulnerability CVE-2020-8911\nSeverity: MEDIUM\nFixed Version: 1.34.0\nLink: [CVE-2020-8911](https://avd.aquasec.com/nvd/cve-2020-8911)"
@@ -1636,7 +1717,7 @@
         },
         {
           "ruleId": "CVE-2022-2582",
-          "ruleIndex": 8,
+          "ruleIndex": 11,
           "level": "warning",
           "message": {
             "text": "Package: github.com/aws/aws-sdk-go\nInstalled Version: v1.25.41\nVulnerability CVE-2022-2582\nSeverity: MEDIUM\nFixed Version: 1.34.0\nLink: [CVE-2022-2582](https://avd.aquasec.com/nvd/cve-2022-2582)"
@@ -1663,7 +1744,7 @@
         },
         {
           "ruleId": "GHSA-76wf-9vgp-pj7w",
-          "ruleIndex": 9,
+          "ruleIndex": 12,
           "level": "warning",
           "message": {
             "text": "Package: github.com/aws/aws-sdk-go\nInstalled Version: v1.25.41\nVulnerability GHSA-76wf-9vgp-pj7w\nSeverity: MEDIUM\nFixed Version: 1.34.0\nLink: [GHSA-76wf-9vgp-pj7w](https://github.com/advisories/GHSA-76wf-9vgp-pj7w)"
@@ -1690,7 +1771,7 @@
         },
         {
           "ruleId": "CVE-2020-8912",
-          "ruleIndex": 10,
+          "ruleIndex": 13,
           "level": "note",
           "message": {
             "text": "Package: github.com/aws/aws-sdk-go\nInstalled Version: v1.25.41\nVulnerability CVE-2020-8912\nSeverity: LOW\nFixed Version: 1.34.0\nLink: [CVE-2020-8912](https://avd.aquasec.com/nvd/cve-2020-8912)"
@@ -1744,7 +1825,7 @@
         },
         {
           "ruleId": "CVE-2022-27664",
-          "ruleIndex": 16,
+          "ruleIndex": 7,
           "level": "error",
           "message": {
             "text": "Package: golang.org/x/net\nInstalled Version: v0.0.0-20220127200216-cd36cc0744dd\nVulnerability CVE-2022-27664\nSeverity: HIGH\nFixed Version: 0.0.0-20220906165146-f3363e06e74c\nLink: [CVE-2022-27664](https://avd.aquasec.com/nvd/cve-2022-27664)"
@@ -1771,7 +1852,7 @@
         },
         {
           "ruleId": "CVE-2022-41723",
-          "ruleIndex": 17,
+          "ruleIndex": 8,
           "level": "error",
           "message": {
             "text": "Package: golang.org/x/net\nInstalled Version: v0.0.0-20220127200216-cd36cc0744dd\nVulnerability CVE-2022-41723\nSeverity: HIGH\nFixed Version: 0.7.0\nLink: [CVE-2022-41723](https://avd.aquasec.com/nvd/cve-2022-41723)"
@@ -1792,87 +1873,6 @@
               },
               "message": {
                 "text": "bin/consul-k8s-control-plane: golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd"
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "CVE-2022-27664",
-          "ruleIndex": 16,
-          "level": "error",
-          "message": {
-            "text": "Package: golang.org/x/net\nInstalled Version: v0.0.0-20211216030914-fe4d6282115f\nVulnerability CVE-2022-27664\nSeverity: HIGH\nFixed Version: 0.0.0-20220906165146-f3363e06e74c\nLink: [CVE-2022-27664](https://avd.aquasec.com/nvd/cve-2022-27664)"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "bin/consul-cni",
-                  "uriBaseId": "ROOTPATH"
-                },
-                "region": {
-                  "startLine": 1,
-                  "startColumn": 1,
-                  "endLine": 1,
-                  "endColumn": 1
-                }
-              },
-              "message": {
-                "text": "bin/consul-cni: golang.org/x/net@v0.0.0-20211216030914-fe4d6282115f"
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "CVE-2022-41723",
-          "ruleIndex": 17,
-          "level": "error",
-          "message": {
-            "text": "Package: golang.org/x/net\nInstalled Version: v0.0.0-20211216030914-fe4d6282115f\nVulnerability CVE-2022-41723\nSeverity: HIGH\nFixed Version: 0.7.0\nLink: [CVE-2022-41723](https://avd.aquasec.com/nvd/cve-2022-41723)"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "bin/consul-cni",
-                  "uriBaseId": "ROOTPATH"
-                },
-                "region": {
-                  "startLine": 1,
-                  "startColumn": 1,
-                  "endLine": 1,
-                  "endColumn": 1
-                }
-              },
-              "message": {
-                "text": "bin/consul-cni: golang.org/x/net@v0.0.0-20211216030914-fe4d6282115f"
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "CVE-2022-32149",
-          "ruleIndex": 21,
-          "level": "error",
-          "message": {
-            "text": "Package: golang.org/x/text\nInstalled Version: v0.3.7\nVulnerability CVE-2022-32149\nSeverity: HIGH\nFixed Version: 0.3.8\nLink: [CVE-2022-32149](https://avd.aquasec.com/nvd/cve-2022-32149)"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "bin/consul-cni",
-                  "uriBaseId": "ROOTPATH"
-                },
-                "region": {
-                  "startLine": 1,
-                  "startColumn": 1,
-                  "endLine": 1,
-                  "endColumn": 1
-                }
-              },
-              "message": {
-                "text": "bin/consul-cni: golang.org/x/text@v0.3.7"
               }
             }
           ]


### PR DESCRIPTION
All github actions now use timestamp based container and chart scan for audit purpose and to avoid unnecessary overlap while syncing up with upstream