### PR TITLE
feat: feat: Enable gossip encryption, TLS, auto-encryption, and CNI…

### DIFF
--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -30,5 +30,5 @@ name: consul
 sources:
   - https://github.com/hashicorp/consul
   - https://github.com/hashicorp/consul-k8s
-version: 1.1.9-dev
+version: 1.1.10-dev
 

--- a/charts/consul/environments/dev/values.yaml
+++ b/charts/consul/environments/dev/values.yaml
@@ -279,13 +279,13 @@ global:
 
   gossipEncryption:
     # Automatically generate a gossip encryption key and save it to a Kubernetes or Vault secret.
-    autoGenerate: false
+    autoGenerate: true
     # The name of the Kubernetes secret or Vault secret path that holds the gossip
     # encryption key. A Kubernetes secret must be in the same namespace that Consul is installed into.
-    secretName: ""
+    secretName: "unoplat-consul-gossip"
     # The key within the Kubernetes secret or Vault secret key that holds the gossip
     # encryption key.
-    secretKey: ""
+    secretKey: "unoplat-consul-gossip-key"
 
   # A list of addresses of upstream DNS servers that are used to recursively resolve DNS queries.
   # These values are given as `-recursor` flags to Consul servers and clients.
@@ -302,12 +302,12 @@ global:
     # servers and clients and all consul-k8s-control-plane components, as well as generate certificate
     # authority (optional) and server and client certificates.
     # This setting is required for [Cluster Peering](https://developer.hashicorp.com/consul/docs/connect/cluster-peering/k8s).
-    enabled: false
+    enabled: true
 
     # If true, turns on the auto-encrypt feature on clients and servers.
     # It also switches consul-k8s-control-plane components to retrieve the CA from the servers
     # via the API. Requires Consul 1.7.1+.
-    enableAutoEncrypt: false
+    enableAutoEncrypt: true
 
     # A list of additional DNS names to set as Subject Alternative Names (SANs)
     # in the server certificate. This is useful when you need to access the
@@ -330,7 +330,7 @@ global:
 
     # If true, the Helm chart will configure Consul to disable the HTTP port on
     # both clients and servers and to only accept HTTPS connections.
-    httpsOnly: true
+    httpsOnly: false
 
     # A secret containing the certificate of the CA to use for TLS communication within the Consul cluster.
     # If you have generated the CA yourself with the consul CLI, you could use the following command to create the secret
@@ -738,7 +738,7 @@ server:
   # servers' StatefulSet storage. For dynamically provisioned storage classes, this is the
   # desired size. For manually defined persistent volumes, this should be set to
   # the disk size of the attached volume.
-  storage: 10Gi
+  storage: 5Gi
 
   # The StorageClass to use for the servers' StatefulSet storage. It must be
   # able to be dynamically provisioned if you want the storage
@@ -755,7 +755,7 @@ server:
   # contains best practices and recommendations for selecting suitable
   # hardware sizes for your Consul servers.
   # @type: string
-  storageClass: null
+  storageClass: civo-volume
 
   # This will enable/disable [Connect](https://developer.hashicorp.com/consul/docs/connect). Setting this to true
   # _will not_ automatically secure pod communication, this
@@ -802,7 +802,7 @@ server:
       cpu: "100m"
     limits:
       memory: "200Mi"
-      cpu: "250m"
+      cpu: "450m"
 
 
   # The security context for the server pods. This should be a YAML map corresponding to a
@@ -1189,7 +1189,7 @@ client:
   # the resources necessary for a Consul client on every Kubernetes node. This _does not_ require
   # `server.enabled`, since the agents can be configured to join an external cluster.
   # @type: boolean
-  enabled: false
+  enabled: true
 
   # The name of the Docker image (including any tag) for the containers
   # running Consul client agents.
@@ -1257,7 +1257,7 @@ client:
       cpu: "100m"
     limits:
       memory: "200Mi"
-      cpu: "200m"
+      cpu: "400m"
 
   # The security context for the client pods. This should be a YAML map corresponding to a
   # Kubernetes [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) object.
@@ -1941,7 +1941,7 @@ connectInject:
     # If true, then all traffic redirection setup uses the consul-cni plugin.
     # Requires connectInject.enabled to also be true.
     # @type: boolean
-    enabled: false
+    enabled: true
 
     # Log level for the installer and plugin. Overrides global.logLevel
     # @type: string
@@ -1986,8 +1986,8 @@ connectInject:
         memory: "75Mi"
         cpu: "75m"
       limits:
-        memory: "100Mi"
-        cpu: "100m"
+        memory: "200Mi"
+        cpu: "400m"
 
     # Resource quotas for running the daemonset as system critical pods
     resourceQuota:
@@ -2147,7 +2147,7 @@ connectInject:
       memory: "200Mi"
       # Recommended production default: 250m
       # @type: string
-      cpu: "100m"
+      cpu: "250m"
 
   # Sets the failurePolicy for the mutating webhook. By default this will cause pods not part of the consul installation to fail scheduling while the webhook
   # is offline. This prevents a pod from skipping mutation if the webhook were to be momentarily offline.
@@ -2316,17 +2316,17 @@ connectInject:
       requests:
         # Recommended production default: 100Mi
         # @type: string
-        memory: null
+        memory: 100Mi
         # Recommended production default: 100m
         # @type: string
-        cpu: null
+        cpu: 100m
       limits:
         # Recommended production default: 100Mi
         # @type: string
-        memory: null
+        memory: 200Mi
         # Recommended production default: 100m
         # @type: string
-        cpu: null
+        cpu: 250m
 
   # The resource settings for the Connect injected init container. If null, the resources
   # won't be set for the initContainer. The defaults are optimized for developer instances of 
@@ -2347,7 +2347,7 @@ connectInject:
         memory: "150Mi"
         # Recommended production default: 500m
         # @type: string
-        cpu: null
+        cpu: 250m
 
 # [Mesh Gateways](https://developer.hashicorp.com/consul/docs/connect/gateways/mesh-gateway) enable Consul Connect to work across Consul datacenters.
 meshGateway:
@@ -2638,8 +2638,8 @@ ingressGateways:
         memory: "100Mi"
         cpu: "100m"
       limits:
-        memory: "100Mi"
-        cpu: "100m"
+        memory: "200Mi"
+        cpu: "250m"
 
     # This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     # for ingress gateway pods. It defaults to `null` thereby allowing multiple gateway pods on each node. But if one would prefer

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1621,7 +1621,7 @@ ui:
     # will inherit from `global.metrics.enabled` value.
     # @type: boolean
     # @default: global.metrics.enabled
-    enabled: "true"
+    enabled: "false"
     # Provider for metrics. Refer to
     # [`metrics_provider`](https://developer.hashicorp.com/consul/docs/agent/config/config-files#ui_config_metrics_provider)
     # This value is only used if `ui.enabled` is set to true.
@@ -1631,7 +1631,7 @@ ui:
     # baseURL is the URL of the prometheus server, usually the service URL.
     # This value is only used if `ui.enabled` is set to true.
     # @type: string
-    baseURL: http://unoplat-observability-prom-prometheus.unoplat-observability:9090
+    baseURL: http://prometheus-server
 
   # Corresponds to [`dashboard_url_templates`](https://developer.hashicorp.com/consul/docs/agent/config/config-files#ui_config_dashboard_url_templates)
   # configuration.


### PR DESCRIPTION
- Enabled gossip encryption with automatic key generation.
- Enabled TLS across the Consul cluster.
- Enabled auto-encryption for Consul clients.
- Storage for consul servers for dev envs kept to 5gbs.
- StorageClass kept to civo volume.
- Consul server limit cpu increased to 450m.
- Changed cpu spec limit for consul agents to 450m.
- Enabled CNI.
- Changed cpu spec limit for cni to 400m and memory to 200 Mi.
- Changed cpu spec limit for connect inject to 250m.
- Modified sidecar proxy cpu request, cpu limit, memory request and memory limit to 100 m,250m,100Mi and 200Mi respectively.
- Modified initContainer cpu limit to 250m.
- Modified resources for ingressgateways. Cpu limit to 250m and memory limit to 200Mi.